### PR TITLE
Functional snapcraft.yaml

### DIFF
--- a/tensorflow/tools/ci_build/snap/snapcraft.yaml
+++ b/tensorflow/tools/ci_build/snap/snapcraft.yaml
@@ -16,19 +16,49 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode # use 'strict' once you have the right plugs and slots
 
+apps:
+  python:
+    command: python
+
 parts:
   tensorflow:
     source: https://github.com/tensorflow/tensorflow/archive/$SNAPCRAFT_PROJECT_VERSION.tar.gz
     plugin: python
     python-version: python2
-
+    python-packages:
+      - six
+      - numpy
+    after: [bazel]
     build-packages:
-      - openjdk-8-jdk
-      - oracle-java8-installer
-      - bazel
-    build:
-      pip install six numpy wheel 
-      cd tensorflow
-      ./configure
+      - wget
+    install: |
+      set -e
+      PYTHON_BIN_PATH="$SNAPCRAFT_PART_INSTALL/usr/bin/python" \
+      PYTHON_LIB_PATH="$SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages" \
+      TF_NEED_MKL=0 \
+      TF_NEED_JEMALLOC=1 \
+      TF_NEED_GCP=0 \
+      TF_NEED_HDFS=0 \
+      TF_ENABLE_XLA=0 \
+      TF_NEED_VERBS=0 \
+      TF_NEED_OPENCL=0 \
+      TF_NEED_CUDA=0 \
+      TF_NEED_MPI=0 \
+      CC_OPT_FLAGS="-march=native" \
+        ./configure
       bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
-      pip install /tmp/tensorflow_pkg/tensorflow-1.3.0-py2-none-any.whl
+      T=$(mktemp -d)
+      bazel-bin/tensorflow/tools/pip_package/build_pip_package $T
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python -m pip install --prefix=$SNAPCRAFT_PART_INSTALL --no-compile $T/*.whl
+  bazel:
+    plugin: nil
+    stage-packages:
+      - unzip
+    install: |
+      BAZEL=bazel-0.5.4-installer-linux-x86_64.sh
+      [ -e $BAZEL ] || wget https://github.com/bazelbuild/bazel/releases/download/0.5.4/$BAZEL
+      chmod +x $BAZEL
+      ./$BAZEL --prefix=$SNAPCRAFT_PART_INSTALL
+    prime:
+      # Only use bazel for building. Do not include it in the final snap.
+      - -*


### PR DESCRIPTION
This gets tensorflow building and installing the python module to the right location. CUDA support (which requires `confinement: classic`) is still outstanding.

To test:

```bash
snapcraft
sudo snap install --dangerous --devmode *.snap
tensorflow.python
```