### PR TITLE
Update version numbers for TensorFlow 9.99.0-rc0

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -18,13 +18,13 @@ limitations under the License.
 
 // TensorFlow uses semantic versioning, see http://semver.org/.
 
-#define TF_MAJOR_VERSION 1
-#define TF_MINOR_VERSION 13
-#define TF_PATCH_VERSION 1
+#define TF_MAJOR_VERSION 9
+#define TF_MINOR_VERSION 99
+#define TF_PATCH_VERSION 0
 
 // TF_VERSION_SUFFIX is non-empty for pre-releases (e.g. "-alpha", "-alpha.1",
 // "-beta", "-rc", "-rc.1")
-#define TF_VERSION_SUFFIX ""
+#define TF_VERSION_SUFFIX "-rc0"
 
 #define TF_STR_HELPER(x) #x
 #define TF_STR(x) TF_STR_HELPER(x)

--- a/tensorflow/tools/docker/Dockerfile.devel
+++ b/tensorflow/tools/docker/Dockerfile.devel
@@ -78,7 +78,7 @@ RUN mkdir /bazel && \
 
 # Download and build TensorFlow.
 WORKDIR /tensorflow
-RUN git clone --branch=r1.13 --depth=1 https://github.com/tensorflow/tensorflow.git .
+RUN git clone --branch=r9.99 --depth=1 https://github.com/tensorflow/tensorflow.git .
 
 # TODO(craigcitro): Don't install the pip package, since it makes it
 # more difficult to experiment with local changes. Instead, just add

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu
@@ -93,7 +93,7 @@ RUN mkdir /bazel && \
 
 # Download and build TensorFlow.
 WORKDIR /tensorflow
-RUN git clone --branch=r1.13 --depth=1 https://github.com/tensorflow/tensorflow.git .
+RUN git clone --branch=r9.99 --depth=1 https://github.com/tensorflow/tensorflow.git .
 
 # Configure the build for our CUDA configuration.
 ENV CI_BUILD_PYTHON python

--- a/tensorflow/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow/tools/docker/Dockerfile.devel-mkl
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 LABEL maintainer="Clayne Robison <clayne.b.robison@intel.com>"
 
 # These parameters can be overridden by parameterized_docker_build.sh
-ARG TF_BUILD_VERSION=r1.13
+ARG TF_BUILD_VERSION=r9.99
 ARG PYTHON="python"
 ARG PYTHON3_DEV=""
 ARG WHL_DIR="/tmp/pip"

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,7 +45,7 @@ DOCLINES = __doc__.split('\n')
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
-_VERSION = '1.13.1'
+_VERSION = '9.99.0-rc0'
 
 REQUIRED_PACKAGES = [
     'absl-py >= 0.7.0',


### PR DESCRIPTION
Before merging this PR, please double check that it has correctly updated
`core/public/version.h` and `tools/pip_package/setup.py`. Also review the
notes below:

```
Detected Major.Minor change.
Updating pattern r1.13 to r9.99 in additional files
Major: 1 -> 9
Minor: 13 -> 99
Patch: 1 -> 0

WARNING: Below are potentially instances of lingering old version string 
"1.13.1" in source directory "tensorflow/" that are not updated by this script. 
Please check them manually!
tensorflow/lite/examples/ios/simple/Podfile:5:1.13.1
tensorflow/lite/examples/ios/camera/Podfile:12:1.13.1

WARNING: Below are potentially instances of lingering old version string 
"1.13.1" in source directory "tensorflow/" that are not updated by this script. 
Please check them manually!
tensorflow/lite/examples/ios/simple/Podfile:5:1.13.1
tensorflow/lite/examples/ios/camera/Podfile:12:1.13.1

WARNING: Below are potentially instances of lingering old version string 
"r1.13" in source directory "tensorflow/" that are not updated by this script. 
Please check them manually!
tensorflow/tools/docker/Dockerfile.mkl:9:r1.13
tensorflow/tools/docker/Dockerfile.devel-mkl-horovod:6:r1.13
tensorflow/tools/docker/Dockerfile.mkl-horovod:9:r1.13
tensorflow/lite/g3doc/convert/quantization.md:26:r1.13
tensorflow/lite/g3doc/performance/model_optimization.md:47:r1.13
tensorflow/lite/g3doc/performance/model_optimization.md:87:r1.13
tensorflow/lite/g3doc/performance/post_training_quantization.md:37:r1.13
tensorflow/lite/g3doc/guide/faq.md:103:r1.13
```